### PR TITLE
Update code so that the crate builds with the latest version of ring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
 /target/
+*.swp
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "lti"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Nick Benoit <nick.benoit14@gmail.com>"]
 description = "Rust library to support the development of LTI tools and applications."
 license = "MIT/Apache-2.0"
 
 [dependencies]
-ring = "0.11"
+ring = "0.17.0-alpha.8"
 url = "1.2.0"
 base64 = "0.5"
 serde_urlencoded = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.3.0"
 authors = ["Nick Benoit <nick.benoit14@gmail.com>"]
 description = "Rust library to support the development of LTI tools and applications."
 license = "MIT/Apache-2.0"
+edition = "2018"
 
 [dependencies]
 ring = "0.17.0-alpha.8"
 url = "1.2.0"
-base64 = "0.5"
-serde_urlencoded = "0.5.1"
+base64 = "0.13.0"
+serde_urlencoded = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 
 [dependencies]
 ring = "0.17.0-alpha.8"
-url = "1.2.0"
+url = "1.7.2"
 base64 = "0.13.0"
 serde_urlencoded = "0.7.0"

--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ LTI standard can be found
 
 ## Installation
 
-Add `lti = "0.2.0"` to your Cargo.toml file
+Add `lti = "0.3.0"` to your Cargo.toml file
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ extern crate url;
 extern crate base64;
 extern crate ring;
 extern crate serde_urlencoded;
-use ring::digest;
 use ring::hmac;
 use url::percent_encoding;
 
@@ -131,7 +130,7 @@ pub fn signature(
     let key = format!("{}&{}",
                       encode(consumer_secret),
                       encode(token_secret.unwrap_or("")));
-    let signing_key = hmac::SigningKey::new(&digest::SHA1, key.as_bytes());
+    let signing_key = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, key.as_bytes());
     let signature = hmac::sign(&signing_key, base.as_bytes());
     base64::encode(signature.as_ref())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,41 +33,36 @@
 //!  );
 //! ```
 
-
-extern crate url;
-extern crate base64;
-extern crate ring;
-extern crate serde_urlencoded;
 use ring::hmac;
 use url::percent_encoding;
 
 // Percent encode string
 fn encode(s: &str) -> String {
      percent_encoding::percent_encode(s.as_bytes(), StrictEncodeSet).collect()
- }
+}
 
 #[derive(Copy, Clone)]
- struct StrictEncodeSet;
+struct StrictEncodeSet;
 
- // Encode all but the unreserved characters defined in
- // RFC 3986, section 2.3. "Unreserved Characters"
- // https://tools.ietf.org/html/rfc3986#page-12
- //
- // This is required by
- // OAuth Core 1.0, section 5.1. "Parameter Encoding"
- // https://oauth.net/core/1.0/#encoding_parameters
- impl percent_encoding::EncodeSet for StrictEncodeSet {
-     #[inline]
-     fn contains(&self, byte: u8) -> bool {
-         !((byte >= 0x61 && byte <= 0x7a) || // A-Z
-           (byte >= 0x41 && byte <= 0x5a) || // a-z
-           (byte >= 0x30 && byte <= 0x39) || // 0-9
-           (byte == 0x2d) || // -
-           (byte == 0x2e) || // .
-           (byte == 0x5f) || // _
-           (byte == 0x7e)) // ~
-     }
- }
+// Encode all but the unreserved characters defined in
+// RFC 3986, section 2.3. "Unreserved Characters"
+// https://tools.ietf.org/html/rfc3986#page-12
+//
+// This is required by
+// OAuth Core 1.0, section 5.1. "Parameter Encoding"
+// https://oauth.net/core/1.0/#encoding_parameters
+impl percent_encoding::EncodeSet for StrictEncodeSet {
+    #[inline]
+    fn contains(&self, byte: u8) -> bool {
+        !((byte >= 0x61 && byte <= 0x7a) || // A-Z
+          (byte >= 0x41 && byte <= 0x5a) || // a-z
+          (byte >= 0x30 && byte <= 0x39) || // 0-9
+          (byte == 0x2d) || // -
+          (byte == 0x2e) || // .
+          (byte == 0x5f) || // _
+          (byte == 0x7e)) // ~
+    }
+}
 
 
 fn parse_launch_params(params: &str) -> Vec<(String, String)>{


### PR DESCRIPTION
This PR mainly updates the dependency on ring from 0.11 (and has been yanked) to 0.17 and adds the corresponding code change. It also updates other dependencies.