### PR TITLE
Use ring 0.16.20 instead of 0.17 for better integration with other crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-ring = "0.17.0-alpha.8"
+ring = "0.16.20"
 url = "1.7.2"
 base64 = "0.13.0"
 serde_urlencoded = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lti"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Nick Benoit <nick.benoit14@gmail.com>"]
 description = "Rust library to support the development of LTI tools and applications."
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
At the time I thought using the latest ring (0.17 alphas) would provide the best long-term. But 0.17 is still in alpha and I'm running into conflict when building with other crates (like `paseto`). In hindsight it's probably better to use the last 0.16 for now.